### PR TITLE
added uninstall script, removed unused code, and tested track state threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "vscode:prepublish": "webpack --mode production",
     "webpack": "webpack --mode development",
     "webpack-dev": "webpack --mode development --watch",
-    "test-compile": "tsc -p ./",
-    "vscode:uninstall": "node ./out/src/Lifecycle"
+    "test-compile": "tsc -p ./"
   },
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "vscode:prepublish": "webpack --mode production",
     "webpack": "webpack --mode development",
     "webpack-dev": "webpack --mode development --watch",
-    "test-compile": "tsc -p ./"
+    "test-compile": "tsc -p ./",
+    "vscode:uninstall": "node ./out/src/Lifecycle"
   },
   "contributes": {
     "commands": [

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -1,0 +1,9 @@
+import { TrackerManager } from "./managers/TrackerManager";
+
+async function uninstall() {
+  const tracker: TrackerManager = TrackerManager.getInstance();
+  await tracker.trackEditorAction("editor", "deactivate");
+  process.exit(0);
+}
+
+uninstall();

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -1,9 +1,0 @@
-import { TrackerManager } from "./managers/TrackerManager";
-
-async function uninstall() {
-  const tracker: TrackerManager = TrackerManager.getInstance();
-  await tracker.trackEditorAction("editor", "deactivate");
-  process.exit(0);
-}
-
-uninstall();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,18 +55,6 @@ export function deactivate(ctx: ExtensionContext) {
   clearInterval(offline_data_interval);
   clearInterval(gather_music_interval);
   clearInterval(check_track_end_interval);
-
-  // softwareDelete(`/integrations/${PLUGIN_ID}`, getItem("jwt")).then(resp => {
-  //     if (isResponseOk(resp)) {
-  //         if (resp.data) {
-  //             console.log(`Uninstalled plugin`);
-  //         } else {
-  //             console.log(
-  //                 "Failed to update Code Time about the uninstall event"
-  //             );
-  //         }
-  //     }
-  // });
 }
 
 export async function activate(ctx: ExtensionContext) {

--- a/src/music/MusicStateManager.ts
+++ b/src/music/MusicStateManager.ts
@@ -13,16 +13,10 @@ import { MusicCommandManager } from "./MusicCommandManager";
 import { MusicDataManager } from "./MusicDataManager";
 import { commands } from "vscode";
 import { getDeviceId, requiresSpotifyAccess } from "./MusicUtil";
-import { CacheManager } from "../cache/CacheManager";
-
-const cacheMgr: CacheManager = CacheManager.getInstance();
 
 const moment = require("moment-timezone");
 
 export class MusicStateManager {
-  static readonly WINDOWS_SPOTIFY_TRACK_FIND: string =
-    'tasklist /fi "imagename eq Spotify.exe" /fo list /v | find " - "';
-
   private static instance: MusicStateManager;
 
   private existingTrack: Track = new Track();
@@ -66,15 +60,6 @@ export class MusicStateManager {
     // offset is the minutes from GMT. it's positive if it's before, and negative after
     const offset = d.getTimezoneOffset();
     return offset * 60;
-  }
-
-  private isEndInRange(playingTrack: Track): boolean {
-    if (!playingTrack || !playingTrack.id) {
-      return false;
-    }
-
-    const buffer = playingTrack.duration_ms * 0.07;
-    return playingTrack.progress_ms >= playingTrack.duration_ms - buffer;
   }
 
   public isExistingTrackPlaying(): boolean {
@@ -146,7 +131,8 @@ export class MusicStateManager {
       const utcLocalTimes = this.getUtcAndLocal();
 
       const diff = utcLocalTimes.utc - this.lastSongCheck;
-      if (diff > 0 && diff < 1) {
+      // 3 second threshold
+      if (diff > 0 && diff < 3) {
         // it's getting called too quickly, bail out
         return;
       }


### PR DESCRIPTION
- bumping the track fetch from 1 second to 3 seconds worked well in regards providing track information without making unnecessary API calls. The calls to this method also have logic to ensure it's called when absolutely necessary, this is just a final gate. This should bump the api calls down significantly, along with the previous removal of the song session POST, which fetched detail song information like album, artists, and features before sending the song out.

- other logic included is the uninstall script. 

Question.. Do we need an "uninstall" editor event or will the "deactivate" be enough?