### PR TITLE
change the node names to prevent code time conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "music-time",
   "displayName": "Music Time for Spotify",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "publisher": "softwaredotcom",
   "description": "Music Time for Spotify is a VS Code extension that discovers the most productive music to listen to as you code.",
   "author": {
@@ -346,12 +346,12 @@
         },
         {
           "command": "musictime.disconnectSlack",
-          "when": "viewItem =~ /.*slack_connection_node.*/",
+          "when": "viewItem =~ /.*musictime_slack_workspace_node.*/",
           "group": "inline@1"
         },
         {
           "command": "musictime.connectSlack",
-          "when": "viewItem =~ /.*slack_connection_parent.*/",
+          "when": "viewItem =~ /.*musictime_slack_folder_parent.*/",
           "group": "inline@1"
         }
       ],

--- a/src/music/ProviderItemManager.ts
+++ b/src/music/ProviderItemManager.ts
@@ -215,12 +215,12 @@ export class ProviderItemManager {
 
   getSlackIntegrationsTree(): KpmItem {
     const parentItem = this.buildKpmItem("Slack workspaces", "", "slack.svg");
-    parentItem.contextValue = "slack_connection_parent";
+    parentItem.contextValue = "musictime_slack_folder_parent";
     parentItem.children = [];
     const workspaces = getSlackWorkspaces();
     for (const integration of workspaces) {
       const workspaceItem = this.buildKpmItem(integration.team_domain, "", "slack.svg");
-      workspaceItem.contextValue = "slack_connection_node";
+      workspaceItem.contextValue = "musictime_slack_workspace_node";
       workspaceItem.description = `(${integration.team_name})`;
       workspaceItem.value = integration.authId;
       parentItem.children.push(workspaceItem);


### PR DESCRIPTION
code time package.json was also looking for the same pattern. this should be distinct for music time